### PR TITLE
Cookie preferences page

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -47,7 +47,7 @@ set :js_dir, "dist/javascripts"
 
 activate :external_pipeline,
   name: :gulp,
-  command: build? ? "./node_modules/gulp/bin/gulp.js --production" : "echo",
+  command: build? ? "./node_modules/gulp/bin/gulp.js --production" : "./node_modules/gulp/bin/gulp.js --watch",
   source: ".tmp",
   latency: 1
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -109,7 +109,9 @@ const build = gulp.series(
     gulp.parallel(css, js, img, fface)
 );
 
-const watch = gulp.watch(scripts.in, js);
+const watch = () => {
+    gulp.watch(scripts.in, js);
+}
 
 // Exports
 exports.clean = clean;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -109,6 +109,8 @@ const build = gulp.series(
     gulp.parallel(css, js, img, fface)
 );
 
+const watch = gulp.watch(scripts.in, js);
+
 // Exports
 exports.clean = clean;
 exports.css = css;
@@ -116,6 +118,7 @@ exports.js = js;
 exports.fface = fface;
 exports.img = img
 exports.build = build;
+exports.watch = watch;
 
 // Default Task
 exports.default = build;

--- a/source/assets/javascripts/cookie_consent.js
+++ b/source/assets/javascripts/cookie_consent.js
@@ -1,43 +1,32 @@
-// Used to set, get and check for cookie consent
-function checkForCookies(name) {
-    return !!getCookie(name);
-}
-
-function getCookie(name) {
-    let cookieArray = document.cookie.split(';');
-    return cookieArray.find(cookieCrumb => cookieCrumb.substring(name.length, 0) === name);
-}
-
-function setCookie(name, value, expiry) {
-    let date = new Date();
-    date.setTime(date.getTime() + (expiry * 24 * 60 * 60 * 1000));
-    let expires = "expires=" + date.toUTCString();
-    document.cookie = name + "=" + value + ";" + expires + ";path=/; sameSite=none; Secure";
-}
+import { checkForCookies, setCookie } from './cookie_helper'
 
 function updateBanner() {
-    document.getElementById("cookieActionsContainer").style.display = "none";
-    document.getElementById("cookieConfirmation").style.display = "block";
+  document.getElementById("cookieActionsContainer").style.display = "none";
+  document.getElementById("cookieConfirmation").style.display = "block";
 }
 
 function unhideBanner() {
-    document.getElementById("appCookieBanner").style.display = "block";
+  document.getElementById("appCookieBanner").style.display = "block";
 }
 
 function hideBanner() {
-    document.getElementById("appCookieBanner").style.display = "none";
+  document.getElementById("appCookieBanner").style.display = "none";
 }
 
 function acceptAllCookies() {
-    setCookie("ghre_allow_cookies", true, 365);
-    updateBanner();
+  setCookie("ghre_allow_cookies", true, 365);
+  updateBanner();
 }
 
-if(!checkForCookies("ghre_allow_cookies")) {
-    unhideBanner(); // unhide cookie banner if consent not given
+function cookieConsentGiven() {
+  return checkForCookies("ghre_allow_cookies");
+}
+
+if (!cookieConsentGiven()) {
+  unhideBanner(); // unhide cookie banner if consent not given
 };
 
 document.getElementById("acceptCookies").onclick = acceptAllCookies;
 document.getElementById("hideButton").onclick = hideBanner;
 
-export { setCookie, getCookie, checkForCookies, acceptAllCookies, hideBanner, unhideBanner };
+export { acceptAllCookies, hideBanner, unhideBanner };

--- a/source/assets/javascripts/cookie_consent.js
+++ b/source/assets/javascripts/cookie_consent.js
@@ -1,4 +1,4 @@
-import { checkForCookies, setCookie } from './cookie_helper'
+import { checkForCookies, getCookie, setCookie } from './cookie_helper'
 
 function updateBanner() {
   document.getElementById("cookieActionsContainer").style.display = "none";
@@ -22,6 +22,18 @@ function cookieConsentGiven() {
   return checkForCookies("ghre_allow_cookies");
 }
 
+function consentToCookies() {
+  setCookie("ghre_allow_cookies", true, 365);
+}
+
+function withdrawCookieConsent() {
+  setCookie("ghre_allow_cookies", false, 365);
+}
+
+function cookieConsentValue() {
+  return getCookie("ghre_allow_cookies");
+}
+
 if (!cookieConsentGiven()) {
   unhideBanner(); // unhide cookie banner if consent not given
 };
@@ -29,4 +41,4 @@ if (!cookieConsentGiven()) {
 document.getElementById("acceptCookies").onclick = acceptAllCookies;
 document.getElementById("hideButton").onclick = hideBanner;
 
-export { acceptAllCookies, hideBanner, unhideBanner };
+export { acceptAllCookies, hideBanner, unhideBanner, consentToCookies, withdrawCookieConsent, cookieConsentValue };

--- a/source/assets/javascripts/cookie_helper.js
+++ b/source/assets/javascripts/cookie_helper.js
@@ -5,12 +5,11 @@ function checkForCookies(name) {
 
 function getCookie(name) {
   let cookieArray = document.cookie.split(';');
-  return cookieArray.find(cookieCrumb => cookieCrumb.substring(name.length, 0) === name);
+  return cookieArray.find(cookieCrumb => cookieCrumb.substring(name.length, 0) === name).split('=')[1];
 }
 
 function setCookie(name, value, expiry) {
   let date = new Date();
-  console.log('woof');
   date.setTime(date.getTime() + (expiry * 24 * 60 * 60 * 1000));
   let expires = "expires=" + date.toUTCString();
   document.cookie = name + "=" + value + ";" + expires + ";path=/; sameSite=none; Secure";

--- a/source/assets/javascripts/cookie_helper.js
+++ b/source/assets/javascripts/cookie_helper.js
@@ -3,9 +3,21 @@ function checkForCookies(name) {
   return !!getCookie(name);
 }
 
-function getCookie(name) {
-  let cookieArray = document.cookie.split(';');
-  return cookieArray.find(cookieCrumb => cookieCrumb.substring(name.length, 0) === name).split('=')[1];
+function getCookie(cname) {
+  var name = cname + "="
+  var decodedCookie = decodeURIComponent(document.cookie)
+  var cookieArray = decodedCookie.split(';')
+
+  for(var i = 0; i < cookieArray.length; i++) {
+    var cookie = cookieArray[i];
+    while (cookie.charAt(0) == ' ') {
+      cookie = cookie.substring(1);
+    }
+    if (cookie.indexOf(name) == 0) {
+      return cookie.substring(name.length, cookie.length);
+    }
+  }
+  return "";
 }
 
 function setCookie(name, value, expiry) {

--- a/source/assets/javascripts/cookie_helper.js
+++ b/source/assets/javascripts/cookie_helper.js
@@ -1,0 +1,19 @@
+// Used to set, get and check for cookie consent
+function checkForCookies(name) {
+  return !!getCookie(name);
+}
+
+function getCookie(name) {
+  let cookieArray = document.cookie.split(';');
+  return cookieArray.find(cookieCrumb => cookieCrumb.substring(name.length, 0) === name);
+}
+
+function setCookie(name, value, expiry) {
+  let date = new Date();
+  console.log('woof');
+  date.setTime(date.getTime() + (expiry * 24 * 60 * 60 * 1000));
+  let expires = "expires=" + date.toUTCString();
+  document.cookie = name + "=" + value + ";" + expires + ";path=/; sameSite=none; Secure";
+}
+
+export { setCookie, getCookie, checkForCookies }

--- a/source/assets/javascripts/cookie_preferences.js
+++ b/source/assets/javascripts/cookie_preferences.js
@@ -17,8 +17,15 @@ function submitCookiePreferences(e) {
   document.querySelector('div[data-cookie-confirmation]').style.display = 'block';
 }
 
+var cookieConsentAccept = 'input[value="cookie-consent-accept"]'
+var cookiePreferencesForm = 'cookie-preferences-form'
+
 if(cookieConsentValue() == 'true') {
-  document.querySelector('input[value="cookie-consent-accept"]').checked = true;
+  if(document.querySelector(cookieConsentAccept)) {
+    document.querySelector(cookieConsentAccept).checked = true;
+  }
 }
 
-document.getElementById('cookie-preferences-form').addEventListener("submit", submitCookiePreferences, false)
+if(document.getElementById(cookiePreferencesForm)) {
+  document.getElementById(cookiePreferencesForm).addEventListener("submit", submitCookiePreferences, false)
+}

--- a/source/assets/javascripts/cookie_preferences.js
+++ b/source/assets/javascripts/cookie_preferences.js
@@ -1,0 +1,24 @@
+import { cookieConsentValue, consentToCookies, withdrawCookieConsent } from './cookie_consent'
+
+function submitCookiePreferences(e) {
+  e.preventDefault();
+  let inputs = e.target.getElementsByTagName('input');
+  for (var i = 0; i < inputs.length; i++) {
+    if (inputs[i].checked) {
+      if (inputs[i].value === 'cookie-consent-accept') {
+        consentToCookies();
+      }
+
+      if (inputs[i].value === 'cookie-consent-deny') {
+        withdrawCookieConsent();
+      }
+    }
+  }
+  document.querySelector('div[data-cookie-confirmation]').style.display = 'block';
+}
+
+if(cookieConsentValue() == 'true') {
+  document.querySelector('input[value="cookie-consent-accept"]').checked = true;
+}
+
+document.getElementById('cookie-preferences-form').addEventListener("submit", submitCookiePreferences, false)

--- a/source/assets/stylesheets/application.scss
+++ b/source/assets/stylesheets/application.scss
@@ -1,2 +1,6 @@
+// Include images from/images/govuk-frontend and fonts from /fonts
+$govuk-images-path: "../images/";
+$govuk-fonts-path: "../fonts/";
+
 @import "govuk-frontend/govuk/all.scss";
 @import "./partials/index";

--- a/source/assets/stylesheets/application.scss
+++ b/source/assets/stylesheets/application.scss
@@ -1,2 +1,2 @@
-@import "./partials/index";
 @import "govuk-frontend/govuk/all.scss";
+@import "./partials/index";

--- a/source/assets/stylesheets/partials/_cookies.scss
+++ b/source/assets/stylesheets/partials/_cookies.scss
@@ -1,0 +1,3 @@
+.govuk-cookies__success--hidden {
+  display: none;
+}

--- a/source/assets/stylesheets/partials/_index.scss
+++ b/source/assets/stylesheets/partials/_index.scss
@@ -1,1 +1,1 @@
-@import 'layout', 'variables';
+@import 'layout', 'variables', 'success_summary', 'cookies';

--- a/source/assets/stylesheets/partials/_success_summary.scss
+++ b/source/assets/stylesheets/partials/_success_summary.scss
@@ -1,0 +1,30 @@
+.govuk-success-summary {
+  @include govuk-text-colour;
+  @include govuk-responsive-padding(4);
+  @include govuk-responsive-margin(8, "bottom");
+
+  border: $govuk-border-width-narrow solid govuk-colour("green");
+
+  &:focus {
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+    // Ensure outline appears outside of the element
+    outline-offset: 0;
+  }
+
+  @include govuk-media-query($from: tablet) {
+    border: $govuk-border-width solid govuk-colour("green");
+  }
+}
+
+.govuk-success-summary,
+.govuk-error-summary {
+  *:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.govuk-success-summary__title {
+  @include govuk-font($size: 24, $weight: bold);
+  @include govuk-responsive-margin(4, "bottom");
+  margin-top: 0;
+}

--- a/source/assets/stylesheets/partials/_variables.scss
+++ b/source/assets/stylesheets/partials/_variables.scss
@@ -1,7 +1,3 @@
-// Include images from/images/govuk-frontend and fonts from /fonts
-$govuk-images-path: "../images/";
-$govuk-fonts-path: "../fonts/";
-
 // Colours
 $cookie-banner-background: #f3f2f1;
 $cookie-banner-text: #0b0c0c;

--- a/source/cookie_preferences.html.erb
+++ b/source/cookie_preferences.html.erb
@@ -1,10 +1,38 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Cookie Preferences</h1>
-    <p class="govuk-body">
-      Lorem ipsum dolor sit amet consectetur adipisicing elit. Eius in neque rem consequuntur 
-      sunt tempora sed aperiam dolores cum omnis, error libero possimus sint aliquid itaque 
-      eveniet alias maxime hic.
-    </p>
+    <div class="govuk-cookies__success--hidden govuk-success-summary" aria-labelledby="success-message" tabindex="-1" role="alert" data-cookie-confirmation="true">
+      <div class="govuk-success-summary__title">
+        <h2 class="govuk-heading-m" id="success-message">
+          Your cookie preferences have been saved
+        </h2>
+      </div>
+    </div>
+    <form id="cookie-preferences-form">
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+            <h3 class="govuk-fieldset__heading">
+              Do you accept Google Analytics cookies?
+            </h3>
+          </legend>
+          <div class="govuk-radios">
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="cookie-consent-accept" name="cookie-consent" type="radio" value="cookie-consent-accept">
+              <label class="govuk-label govuk-radios__label" for="cookie-consent-accept">
+                Yes, opt-in to Google Analytics cookies
+              </label>
+            </div>
+            <div class="govuk-radios__item">
+              <input class="govuk-radios__input" id="cookie-consent-deny" name="cookie-consent" type="radio" value="cookie-consent-deny" checked>
+              <label class="govuk-label govuk-radios__label" for="cookie-consent-deny">
+                No, do not track my website usage
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+      <button type="submit" class="govuk-button" data-module="govuk-button">Save changes</button>
+    </form>
   </div>
 </div>


### PR DESCRIPTION
## What?

Adds the beginnings of the cookie preferences page for allowing/denying cookies

### Screenshots

![image](https://user-images.githubusercontent.com/976254/99810679-fe090180-2b3b-11eb-87b3-003764b6ef9e.png)

![image](https://user-images.githubusercontent.com/976254/99810726-0bbe8700-2b3c-11eb-9ac7-af2d5306b3df.png)

## Why?

If we want to add google analytics we need to make sure that users only get it enabled when they opt-in to it - as such we need the ability to opt-in/out of it. 

As we don't have any server-side logic, this form needs to be handled via javascript only for now.