### PR TITLE
correct env assignment

### DIFF
--- a/.github/workflows/deploy_to_dev.yml
+++ b/.github/workflows/deploy_to_dev.yml
@@ -53,13 +53,13 @@ jobs:
           terraform apply -auto-approve -var-file workspace-variables/dev.tfvars
         working-directory: terraform
         env:
-          TF_VAR_monitoring_username="${{ secrets.MONITORING_USER }}"
-          TF_VAR_monitoring_password="${{ secrets.MONITORING_PASSWORD }}"
-          TF_VAR_grafana_admin_password="${{ secrets.GRAFANA_ADMIN_PASSWORD_DEV }}"
-          TF_VAR_statuscake_username="${{ secrets.STATUSCAKE_USERNAME }}"
-          TF_VAR_statuscake_apikey="${{ secrets.STATUSCAKE_APIKEY }}"
-          TF_VAR_paas_username="${{ secrets.CF_USER_DEV }}"
-          TF_VAR_paas_password="${{ secrets.CF_PASSWORD_DEV }}"
+          TF_VAR_monitoring_username: ${{ secrets.MONITORING_USER }}
+          TF_VAR_monitoring_password: ${{ secrets.MONITORING_PASSWORD }}
+          TF_VAR_grafana_admin_password: ${{ secrets.GRAFANA_ADMIN_PASSWORD_DEV }}
+          TF_VAR_statuscake_username: ${{ secrets.STATUSCAKE_USERNAME }}
+          TF_VAR_statuscake_apikey: ${{ secrets.STATUSCAKE_APIKEY }}
+          TF_VAR_paas_username: ${{ secrets.CF_USER_DEV }}
+          TF_VAR_paas_password: ${{ secrets.CF_PASSWORD_DEV }}
 
       - name: run tests
         run: |

--- a/.github/workflows/deploy_to_prod.yml
+++ b/.github/workflows/deploy_to_prod.yml
@@ -49,13 +49,13 @@ jobs:
           terraform apply -auto-approve -var-file workspace-variables/prod.tfvars
         working-directory: terraform
         env:
-          TF_VAR_monitoring_username="${{ secrets.MONITORING_USER }}"
-          TF_VAR_monitoring_password="${{ secrets.MONITORING_PASSWORD }}"
-          TF_VAR_grafana_admin_password="${{ secrets.GRAFANA_ADMIN_PASSWORD_PROD }}"
-          TF_VAR_statuscake_username="${{ secrets.STATUSCAKE_USERNAME }}"
-          TF_VAR_statuscake_apikey="${{ secrets.STATUSCAKE_APIKEY }}"
-          TF_VAR_paas_username="${{ secrets.CF_USER_PROD }}"
-          TF_VAR_paas_password="${{ secrets.CF_PASSWORD_PROD }}"
+          TF_VAR_monitoring_username: ${{ secrets.MONITORING_USER }}
+          TF_VAR_monitoring_password: ${{ secrets.MONITORING_PASSWORD }}
+          TF_VAR_grafana_admin_password: ${{ secrets.GRAFANA_ADMIN_PASSWORD_PROD }}
+          TF_VAR_statuscake_username: ${{ secrets.STATUSCAKE_USERNAME }}
+          TF_VAR_statuscake_apikey: ${{ secrets.STATUSCAKE_APIKEY }}
+          TF_VAR_paas_username: ${{ secrets.CF_USER_PROD }}
+          TF_VAR_paas_password: ${{ secrets.CF_PASSWORD_PROD }}
 
       - name: run tests
         run: |


### PR DESCRIPTION
- Correct env assignment by replacing '=' with ':'