### PR TITLE
Use new shared monitoring module

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,7 +1,7 @@
 module prometheus_all {
   for_each = toset(var.monitoring_instances)
 
-  source = "git::https://github.com/DFE-Digital/bat-platform-building-blocks.git//terraform/modules/prometheus_all"
+  source = "git::https://github.com/DFE-Digital/cf-monitoring.git//prometheus_all"
 
   monitoring_instance_name = "ghre-${each.value}"
   monitoring_org_name      = local.paas_org_name


### PR DESCRIPTION
## What
The shared monitoring terraform module is being migrated to its own repository and the current one will be deprecated

## How to review
Run monitoring-plan