### PR TITLE
Content updates  for 8 March return

### DIFF
--- a/ghre-rails/app/views/pages/good_teaching_practice.html.erb
+++ b/ghre-rails/app/views/pages/good_teaching_practice.html.erb
@@ -64,6 +64,8 @@
       </p>
     </div>
     <h2 class="govuk-heading-l">Schools</h2>
+    <% schools_update_date = t('good_teaching_practice.schools.last_update').to_date %>
+    <%= render layout: 'summary', locals: { update_date: schools_update_date, show_updates: @show_updates, page: 'good-teaching-practice', has_content: false } do; end %>
     <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
       <div class="govuk-accordion__section ">
         <div class="govuk-accordion__section-header">
@@ -197,7 +199,12 @@
       <div class="govuk-accordion__section ">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-default-heading-3">
+            <span
+              class="govuk-accordion__section-button updated-content <%= 'active' if @show_updates %>"
+              data-qa="updated-content<%= @show_updates ? '__highlighted' : '' %>"
+              data-updated
+              id="accordion-default-heading-3"
+            >
               Webinars
             </span>
           </h2>
@@ -208,8 +215,14 @@
             The DfE is offering several <%= link_to_govuk_content("school-led webinars", "https://www.gov.uk/guidance/remote-education-webinars") %> on remote education
             to help share good practice.
           </p>
-          <h4 class="govuk-heading-s">EdTech Demonstrator webinars</h4>
-          <p class="govuk-body">
+          <h4
+            class="govuk-heading-s"
+          >EdTech Demonstrator webinars</h4>
+          <p
+            class="govuk-body updated-content <%= 'active' if @show_updates %>"
+            data-qa="updated-content<%= @show_updates ? '__highlighted' : '' %>"
+            data-updated
+          >
             <a class="govuk-link" href="https://edtech-demonstrator.lgfl.net/home">The EdTech Demonstrator programme</a> helps schools and colleges with support for remote
             education. Their webinars can help improve the quality of remote provision in line with the expectations set out in the 
             <%= link_to_govuk_content("Schools coronavirus (COVID-19) operational guidance", "https://www.gov.uk/government/publications/actions-for-schools-during-the-coronavirus-outbreak") %>.
@@ -246,8 +259,7 @@
       </div>
     </div>
     <h2 class="govuk-heading-l">FE</h2>
-    <% fe_update_date = t('good_teaching_practice.fe.last_update').to_date %>
-    <%= render layout: 'summary', locals: { update_date: fe_update_date, show_updates: @show_updates, page: 'good-teaching-practice', has_content: false } do; end %>
+    <span class="govuk-heading-s update-summary-meta">updated <%= t('good_teaching_practice.fe.last_update').to_date().strftime('%-d %B') %></span>
 
     <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
       <div class="govuk-accordion__section ">
@@ -304,8 +316,18 @@
             Object Reference Model (SCORM) compliant resources for use across the FE curriculum.
           </p>
 
-          <h4 class="govuk-heading-s">EdTech Demonstrator webinars</h4>
-          <p class="govuk-body">
+          <h4
+            class="govuk-heading-s updated-content  <%= 'active' if @show_updates %>"
+            data-qa="updated-content<%= @show_updates ? '__highlighted' : '' %>"
+            data-updated
+          >
+            EdTech Demonstrator webinars
+          </h4>
+          <p
+            class="govuk-body updated-content  <%= 'active' if @show_updates %>"
+            data-qa="updated-content<%= @show_updates ? '__highlighted' : '' %>"
+            data-updated
+          >
             <a class="govuk-link" href="https://edtech-demonstrator.lgfl.net/home">The EdTech Demonstrator programme</a> helps schools and colleges with support for remote
             education. Their webinars can help improve the quality of remote provision in line with the expectations set out in the 
             <%= link_to_govuk_content("Further education coronavirus (COVID-19) operational guidance", "https://www.gov.uk/government/publications/coronavirus-covid-19-maintaining-further-education-provision") %>.

--- a/ghre-rails/app/views/pages/good_teaching_practice.html.erb
+++ b/ghre-rails/app/views/pages/good_teaching_practice.html.erb
@@ -211,9 +211,10 @@
           <h4 class="govuk-heading-s">EdTech Demonstrator webinars</h4>
           <p class="govuk-body">
             <a class="govuk-link" href="https://edtech-demonstrator.lgfl.net/home">The EdTech Demonstrator programme</a> helps schools and colleges with support for remote
-            education. Their webinars can support schools that are looking for help to improve the quality of their remote provision in line with the expectations
-            set out in the guidance on 
-            <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/950510/School_national_restrictions_guidance.pdf" class="govuk-link"> restricting attendance during the national lockdown</a>.
+            education. Their webinars can help improve the quality of remote provision in line with the expectations set out in the 
+            <%= link_to_govuk_content("Schools coronavirus (COVID-19) operational guidance", "https://www.gov.uk/government/publications/actions-for-schools-during-the-coronavirus-outbreak") %>.
+          </p>
+          <p class="govuk-body">
             Webinars include:
           </p>
           <ul class="govuk-list govuk-list--bullet">
@@ -301,6 +302,13 @@
           <p class="govuk-body">
             DfE has also funded colleges to produce a range of content for the FE sector. The content consists of free, Sharable Content
             Object Reference Model (SCORM) compliant resources for use across the FE curriculum.
+          </p>
+
+          <h4 class="govuk-heading-s">EdTech Demonstrator webinars</h4>
+          <p class="govuk-body">
+            <a class="govuk-link" href="https://edtech-demonstrator.lgfl.net/home">The EdTech Demonstrator programme</a> helps schools and colleges with support for remote
+            education. Their webinars can help improve the quality of remote provision in line with the expectations set out in the 
+            <%= link_to_govuk_content("Further education coronavirus (COVID-19) operational guidance", "https://www.gov.uk/government/publications/coronavirus-covid-19-maintaining-further-education-provision") %>.
           </p>
 
           <h4 class="govuk-heading-s">Agriculture, horticulture, and animal care</h4>

--- a/ghre-rails/app/views/pages/safeguarding.html.erb
+++ b/ghre-rails/app/views/pages/safeguarding.html.erb
@@ -8,6 +8,9 @@
 </h1>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% safeguarding_update_date = t('safeguarding.last_update_date').to_date %>
+    <%= render layout: 'summary', locals: { update_date: safeguarding_update_date, show_updates: @show_updates, page: 'safeguarding', has_content: false } do %>
+    <% end %>
     <p class="govuk-body">
       Keeping children safe online is essential. The statutory guidance
       <%= link_to_govuk_content("Keeping children safe in education", "https://www.gov.uk/government/publications/keeping-children-safe-in-education--2") %>
@@ -26,7 +29,11 @@
       <%= link_to_govuk_content("Safeguarding and remote education during coronavirus (COVID-19)", "https://www.gov.uk/guidance/safeguarding-and-remote-education-during-coronavirus-covid-19") %> provides guidance
       to help schools, colleges and teachers support pupils' and students' remote education during coronavirus (COVID-19).
     </p>
-    <p class="govuk-body">
+    <p
+      class="govuk-body updated-content  <%= 'active' if @show_updates %>"
+      data-qa="updated-content<%= @show_updates ? '__highlighted' : '' %>"
+      data-updated
+    >
       The
       <%= link_to_govuk_content("Further education coronavirus (COVID-19) operational guidance", "https://www.gov.uk/government/publications/coronavirus-covid-19-maintaining-further-education-provision") %>
       provides specific guidance for safeguarding in further education (p43).

--- a/ghre-rails/app/views/pages/safeguarding.html.erb
+++ b/ghre-rails/app/views/pages/safeguarding.html.erb
@@ -27,7 +27,8 @@
       to help schools, colleges and teachers support pupils' and students' remote education during coronavirus (COVID-19).
     </p>
     <p class="govuk-body">
-      <%= link_to_govuk_content("Further Education guidance for operation during the national lockdown", "https://www.gov.uk/government/publications/actions-for-schools-during-the-coronavirus-outbreak") %>
+      The
+      <%= link_to_govuk_content("Further education coronavirus (COVID-19) operational guidance", "https://www.gov.uk/government/publications/coronavirus-covid-19-maintaining-further-education-provision") %>
       provides specific guidance for safeguarding in further education (p43).
     </p>
     <p class="govuk-body">

--- a/ghre-rails/app/views/pages/send.html.erb
+++ b/ghre-rails/app/views/pages/send.html.erb
@@ -16,10 +16,18 @@
       all types of school. 
     </p>
     <h2 class="govuk-heading-l">Guidance</h2>
-    <p class="govuk-body">
+    <p
+      class="govuk-body updated-content  <%= 'active' if @show_updates %>"
+      data-qa="updated-content<%= @show_updates ? '__highlighted' : '' %>"
+      data-updated
+    >
       Where a pupil, class, group or small number of pupils need to self-isolate, or there are local restrictions in place requiring pupils to remain at home, DfE expects schools to be able to immediately offer them access to remote education.
     </p>
-    <p class="govuk-body">
+    <p
+      class="govuk-body updated-content  <%= 'active' if @show_updates %>"
+      data-qa="updated-content<%= @show_updates ? '__highlighted' : '' %>"
+      data-updated
+    >
       You can read the
       <%= link_to_govuk_content("guidance", "https://www.gov.uk/government/publications/actions-for-schools-during-the-coronavirus-outbreak") %>
       on supporting pupils and students with SEND for remote education. (pg 48)

--- a/ghre-rails/app/views/pages/send.html.erb
+++ b/ghre-rails/app/views/pages/send.html.erb
@@ -17,9 +17,12 @@
     </p>
     <h2 class="govuk-heading-l">Guidance</h2>
     <p class="govuk-body">
-      You can read the guidance on supporting pupils and students with SEND within the guidance on 
-      <a class="govuk-link" href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/950510/School_national_restrictions_guidance.pdf">
-        restricting attendance during the national lockdown</a>.
+      Where a pupil, class, group or small number of pupils need to self-isolate, or there are local restrictions in place requiring pupils to remain at home, DfE expects schools to be able to immediately offer them access to remote education.
+    </p>
+    <p class="govuk-body">
+      You can read the
+      <%= link_to_govuk_content("guidance", "https://www.gov.uk/government/publications/actions-for-schools-during-the-coronavirus-outbreak") %>
+      on supporting pupils and students with SEND for remote education. (pg 48)
     </p>
     <h2 class="govuk-heading-l">Get devices for those who cannot attend school</h2>
     <p class="govuk-body">

--- a/ghre-rails/app/views/pages/statutory_obligations.html.erb
+++ b/ghre-rails/app/views/pages/statutory_obligations.html.erb
@@ -9,33 +9,17 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">
-      This page provides information on current remote education obligations and expectations.  
+      This page provides information on current remote education obligations and expectations.
     </p>
     <div class="event-panel">
       <p class="govuk-body">
-        From 8 March onwards, pupils and students will be returning to on-site education.
-        Read more about remote education requirements from 8 March for 
-        <a 
-          class="govuk-link" 
-          href="https://www.gov.uk/government/publications/actions-for-schools-during-the-coronavirus-outbreak"
-        >
-          schools</a>
+        From 8 March, pupils and students will be returning to on-site education. Read more about returning to
+        <%= link_to_govuk_content("schools", "https://www.gov.uk/government/publications/actions-for-schools-during-the-coronavirus-outbreak") %>
         and 
-        <a 
-          class="govuk-link" 
-          href="https://www.gov.uk/government/publications/coronavirus-covid-19-maintaining-further-education-provision"
-        >
-          further education (FE) colleges</a>.
+        <%= link_to_govuk_content("further education (FE) colleges", "https://www.gov.uk/government/publications/coronavirus-covid-19-maintaining-further-education-provision") %>
+          as well as provision for remote education.
       </p>
     </div>
-    <p class="govuk-body">
-      From 5 January 2021, all schools and FE colleges closed to most pupils and students due to coronavirus (COVID-19).  
-      Read the remote education expectations for 
-      <a class="govuk-link" href="https://get-help-with-remote-education.education.gov.uk/statutory-obligations#schools">schools</a>
-      and for
-      <a class="govuk-link" href="https://get-help-with-remote-education.education.gov.uk/statutory-obligations#further-education">
-        FE colleges</a>.
-    </p>
     <% main_title_paragraph_update_date = t('statutory_obligations.main_title_paragraph.last_update').to_date %>
     <%= render layout: 'summary', locals: { update_date: main_title_paragraph_update_date, show_updates: @show_updates, page: 'statutory-obligations', has_content: false } do %>
     <% end %>
@@ -50,8 +34,9 @@
       data-updated
       data-qa="updated-content<%= @show_updates ? '__highlighted' : '' %>"
     >
-      The remote education expectations are set out within the guidance on 
-      <a href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/950510/School_national_restrictions_guidance.pdf" class="govuk-link">restricting attendance during the national lockdown</a>.
+      Where a pupil, class, group or small number of pupils need to self-isolate, or there are local restrictions in place requiring pupils to remain at home, DfE expects schools to be able to immediately offer them access to remote education. The 
+      <%= link_to_govuk_content("Schools coronavirus (COVID-19) operational guidance", "https://www.gov.uk/government/publications/actions-for-schools-during-the-coronavirus-outbreak") %>
+      sets out what’s expected of schools’ remote provision. (Pg 45).
     </p>
     <p class="govuk-body">
       The Secretary of State for Education has given a temporary continuity direction which requires schools to provide remote education for state-funded, school-age children unable
@@ -70,7 +55,7 @@
       Read the addendum on
       <%= link_to_govuk_content("recording attendance in relation to coronavirus (COVID-19)", "https://www.gov.uk/government/publications/school-attendance/addendum-recording-attendance-in-relation-to-coronavirus-covid-19-during-the-2020-to-2021-academic-year") %>
       for further information. Where there is a different reason for absence, read the
-      <a class="govuk-link" href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/907535/School_attendance_guidance_for_2020_to_2021_academic_year.pdf">school attendance guidance.</a>
+      <%= link_to_govuk_content("school attendance guidance.", "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/907535/School_attendance_guidance_for_2020_to_2021_academic_year.pdf") %>
     </p>
     <p class="govuk-body">
       Schools should keep a record of, and monitor pupils’ and students’ engagement with remote education, but this does not need to be tracked in the attendance register.
@@ -86,8 +71,9 @@
       data-updated
       data-qa="updated-content<%= @show_updates ? '__highlighted' : '' %>"
     >
-      Read the 
-      <%= link_to_govuk_content("actions for FE colleges and providers during the coronavirus outbreak", "https://www.gov.uk/government/publications/coronavirus-covid-19-maintaining-further-education-provision") %>.
+      Where restrictions are put in place to contain local outbreaks or pupils and students are required to self-isolate, remote provision can be extended to meet pupils’ and students’ needs. FE colleges should have contingency plans in place to move quickly to blended or, if necessary, remote education should the need arise. The 
+      <%= link_to_govuk_content("Further education coronavirus (COVID-19) operational guidance", "https://www.gov.uk/government/publications/coronavirus-covid-19-maintaining-further-education-provision") %>
+      sets out what’s expected for remote provision. (pg 28)
     </p>
     <p 
       class="govuk-body updated-content <%= 'active' if @show_updates %>"

--- a/ghre-rails/config/locales/en.yml
+++ b/ghre-rails/config/locales/en.yml
@@ -31,19 +31,19 @@
 
 en:
   statutory_obligations:
-    last_update_date: "08/01/2021"
+    last_update_date: "08/03/2021"
     main_title_paragraph: 
-      last_update: "08/01/2021"
+      last_update: "08/03/2021"
   safeguarding:
-    last_update_date: "11/02/2021"
+    last_update_date: "08/03/2021"
   good_teaching_practice:
-    last_update_date: "03/03/2021"
+    last_update_date: "08/03/2021"
     schools:
-      last_update: "12/01/2021"
+      last_update: "08/03/2021"
     fe:
-      last_update: "03/03/2021"
+      last_update: "08/03/2021"
   send:
-    last_update_date: "06/01/2021"
+    last_update_date: "08/03/2021"
     training_in_assistive_technology:
       last_update: "06/01/2021"
   review_framework:


### PR DESCRIPTION
Mar 8th return content updates, affecting the following pages:
- `/good-teaching-practice`
- `/safeguarding`
- `/send`
- `/statutory-obligations`