### PR TITLE
Github Actions Update

### DIFF
--- a/.github/workflows/deploy_rails_to_dev.yml
+++ b/.github/workflows/deploy_rails_to_dev.yml
@@ -27,8 +27,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ghre-docker
-          password: ${{ secrets.GH_USER_GHRE_DOCKER_PAT }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2

--- a/.github/workflows/deploy_rails_to_dev.yml
+++ b/.github/workflows/deploy_rails_to_dev.yml
@@ -1,6 +1,6 @@
 name: Deploy rails to dev
 
-# Workflow will run on push to main branch & open PR
+# Workflow will run on manual trigger in github actions UI
 on:
   workflow_dispatch:
 
@@ -16,17 +16,26 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v1
+          echo "::set-output name=image_commit_tag::ghcr.io/dfe-digital/get-help-with-remote-education-dev:$(git rev-parse --short HEAD)"
+          echo "::set-output name=image_latest_tag::ghcr.io/dfe-digital/get-help-with-remote-education-dev:latest"
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
         with:
-          path: ./ghre-rails
-          dockerfile: ./ghre-rails/Dockerfile
+          registry: ghcr.io
           username: ghre-docker
           password: ${{ secrets.GH_USER_GHRE_DOCKER_PAT }}
-          registry: ghcr.io
-          repository: dfe-digital/get-help-with-remote-education-dev
-          tags: ${{ steps.vars.outputs.sha_short }}, latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./ghre-rails
+          push: true
+          tags: ${{ steps.vars.outputs.image_commit_tag }}, ${{ steps.vars.outputs.image_latest_tag }}
 
   deploy-to-paas:
     defaults:
@@ -41,7 +50,7 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+          echo "::set-output name=image_commit_tag::ghcr.io/dfe-digital/get-help-with-remote-education-dev:$(git rev-parse --short HEAD)"
       - name: Install CloudFoundry CLI
         shell: bash
         id: install-cf-cli
@@ -54,9 +63,9 @@ jobs:
         id: deploy-to-paas
         shell: bash
         env:
-          GH_IMAGE_COMMIT_TAG: ${{ steps.vars.outputs.sha_short }}
+          GH_IMAGE_COMMIT_TAG: ${{ steps.vars.outputs.image_commit_tag }}
         run: |
           cf api https://api.london.cloud.service.gov.uk
           cf auth "${{ secrets.CF_USER_DEV }}" "${{ secrets.CF_PASSWORD_DEV }}"
           cf target -o dfe -s get-help-with-remote-education-dev
-          cf push -f ./config/manifests/dev_manifest.yml --docker-image ghcr.io/dfe-digital/get-help-with-remote-education-dev:$GH_IMAGE_COMMIT_TAG
+          cf push -f ./config/manifests/dev_manifest.yml --docker-image $GH_IMAGE_COMMIT_TAG

--- a/.github/workflows/deploy_rails_to_prod.yml
+++ b/.github/workflows/deploy_rails_to_prod.yml
@@ -1,6 +1,6 @@
 name: Deploy rails to prod
 
-# Workflow will run on push to main branch
+# Workflow will run on manual trigger in github actions UI
 on:
   workflow_dispatch:
 
@@ -16,19 +16,26 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "##[set-output name=branch;]$(git rev-parse --abbrev-ref HEAD)"
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v1
+          echo "::set-output name=image_commit_tag::ghcr.io/dfe-digital/get-help-with-remote-education-prod:$(git rev-parse --short HEAD)"
+          echo "::set-output name=image_latest_tag::ghcr.io/dfe-digital/get-help-with-remote-education-prod:latest"
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
         with:
-          build_args: GIT_COMMIT_SHA=${{ steps.vars.outputs.sha_short }},GIT_BRANCH=${{ steps.vars.outputs.branch }}
-          path: ./ghre-rails
-          dockerfile: ./ghre-rails/Dockerfile
+          registry: ghcr.io
           username: ghre-docker
           password: ${{ secrets.GH_USER_GHRE_DOCKER_PAT }}
-          registry: ghcr.io
-          repository: dfe-digital/get-help-with-remote-education-prod
-          tags: ${{ steps.vars.outputs.sha_short }}, latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./ghre-rails
+          push: true
+          tags: ${{ steps.vars.outputs.image_commit_tag }}, ${{ steps.vars.outputs.image_latest_tag }}
 
   deploy-to-paas:
     defaults:
@@ -43,7 +50,7 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+          echo "::set-output name=image_commit_tag::ghcr.io/dfe-digital/get-help-with-remote-education-prod:$(git rev-parse --short HEAD)"
       - name: Install CloudFoundry CLI
         shell: bash
         id: install-cf-cli
@@ -80,9 +87,9 @@ jobs:
         id: deploy-to-paas
         shell: bash
         env:
-          GH_IMAGE_COMMIT_TAG: ${{ steps.vars.outputs.sha_short }}
+          GH_IMAGE_COMMIT_TAG: ${{ steps.vars.outputs.image_commit_tag }}
         run: |
           cf api https://api.london.cloud.service.gov.uk
           cf auth "${{ secrets.CF_USER_PROD }}" "${{ secrets.CF_PASSWORD_PROD }}"
           cf target -o dfe -s get-help-with-remote-education-prod
-          cf push -f ./config/manifests/prod_manifest.yml --docker-image ghcr.io/dfe-digital/get-help-with-remote-education-prod:$GH_IMAGE_COMMIT_TAG --strategy rolling
+          cf push -f ./config/manifests/prod_manifest.yml --docker-image $GH_IMAGE_COMMIT_TAG

--- a/.github/workflows/deploy_rails_to_prod.yml
+++ b/.github/workflows/deploy_rails_to_prod.yml
@@ -27,8 +27,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ghre-docker
-          password: ${{ secrets.GH_USER_GHRE_DOCKER_PAT }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2

--- a/.github/workflows/deploy_rails_to_staging.yml
+++ b/.github/workflows/deploy_rails_to_staging.yml
@@ -27,8 +27,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ghre-docker
-          password: ${{ secrets.GH_USER_GHRE_DOCKER_PAT }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2

--- a/.github/workflows/deploy_rails_to_staging.yml
+++ b/.github/workflows/deploy_rails_to_staging.yml
@@ -1,6 +1,6 @@
 name: Deploy rails to staging
 
-# Workflow will run on push to main branch
+# Workflow will run on manual trigger in github actions UI
 on:
   workflow_dispatch:
 
@@ -16,19 +16,26 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "##[set-output name=branch;]$(git rev-parse --abbrev-ref HEAD)"
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v1
+          echo "::set-output name=image_commit_tag::ghcr.io/dfe-digital/get-help-with-remote-education-staging:$(git rev-parse --short HEAD)"
+          echo "::set-output name=image_latest_tag::ghcr.io/dfe-digital/get-help-with-remote-education-staging:latest"
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
         with:
-          build_args: GIT_COMMIT_SHA=${{ steps.vars.outputs.sha_short }},GIT_BRANCH=${{ steps.vars.outputs.branch }}
-          path: ./ghre-rails
-          dockerfile: ./ghre-rails/Dockerfile
+          registry: ghcr.io
           username: ghre-docker
           password: ${{ secrets.GH_USER_GHRE_DOCKER_PAT }}
-          registry: ghcr.io
-          repository: dfe-digital/get-help-with-remote-education-staging
-          tags: ${{ steps.vars.outputs.sha_short }}, latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./ghre-rails
+          push: true
+          tags: ${{ steps.vars.outputs.image_commit_tag }}, ${{ steps.vars.outputs.image_latest_tag }}
 
   deploy-to-paas:
     defaults:
@@ -43,7 +50,7 @@ jobs:
         id: vars
         shell: bash
         run: |
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+          echo "::set-output name=image_commit_tag::ghcr.io/dfe-digital/get-help-with-remote-education-staging:$(git rev-parse --short HEAD)"
       - name: Install CloudFoundry CLI
         shell: bash
         id: install-cf-cli
@@ -56,9 +63,9 @@ jobs:
         id: deploy-to-paas
         shell: bash
         env:
-          GH_IMAGE_COMMIT_TAG: ${{ steps.vars.outputs.sha_short }}
+          GH_IMAGE_COMMIT_TAG: ${{ steps.vars.outputs.image_commit_tag }}
         run: |
           cf api https://api.london.cloud.service.gov.uk
           cf auth "${{ secrets.CF_USER_STAGING }}" "${{ secrets.CF_PASSWORD_STAGING }}"
           cf target -o dfe -s get-help-with-remote-education-staging
-          cf push -f ./config/manifests/staging_manifest.yml --docker-image ghcr.io/dfe-digital/get-help-with-remote-education-staging:$GH_IMAGE_COMMIT_TAG
+          cf push -f ./config/manifests/staging_manifest.yml --docker-image $GH_IMAGE_COMMIT_TAG

--- a/docs/docker_registry.md
+++ b/docs/docker_registry.md
@@ -9,10 +9,4 @@ Our containers are held in the DfE github organisation, with admin rights just f
 
 ## CI - Github Actions
 
-The `GITHUB_TOKEN` actions environment variable runs [doesn't have permissions to push to ghcr](https://docs.github.com/en/packages/guides/migrating-to-github-container-registry-for-docker-images#updating-your-github-actions-workflow) unfortunately, so we've followed github's suggestion of creating a [machine user](https://docs.github.com/en/developers/overview/managing-deploy-keys#machine-users).
-
-The machine user is [ghre-docker](https://github.com/ghre-docker), which is linked to the ghre-docker@digital.education.gov.uk group email address.
-
-A personal access token (PAT) for ghre-docker with repo & package write & read permissions is stored in a repo secret, `GH_USER_GHRE_DOCKER_PAT`.
-
-2 factor authentication is a requirement for the DfE github org, the 2fa recovery codes for the ghre-docker machine user should be safely stored and handed over if dev team members change. https://docs.github.com/en/github/authenticating-to-github/recovering-your-account-if-you-lose-your-2fa-credentials
+The `GITHUB_TOKEN` actions environment variable [is used to authorize the image push](https://docs.github.com/en/packages/guides/migrating-to-github-container-registry-for-docker-images#updating-your-github-actions-workflow).


### PR DESCRIPTION
- Update docker/build-push-action from deprecated v1 to v2
- Use GITHUB_TOKEN rather than machine user PAT. [Now allowed](https://docs.github.com/en/packages/guides/configuring-docker-for-use-with-github-packages#authenticating-to-github-packages)