### PR TITLE
Improve dev

### DIFF
--- a/ghre-rails/config/environments/development.rb
+++ b/ghre-rails/config/environments/development.rb
@@ -48,7 +48,8 @@ Rails.application.configure do
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
 
-  # Use an evented file watcher to asynchronously detect changes in source code,
-  # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  # Use a file watcher to asynchronously detect changes in source code,
+  # routes, locales, etc. Usually this uses EventedFileUpdateChecker,
+  # but that doesn't play nicely with Docker
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 end

--- a/ghre-rails/docker-compose.yaml
+++ b/ghre-rails/docker-compose.yaml
@@ -18,3 +18,5 @@ services:
       - "3001:3000"
     depends_on:
       - db
+    volumes:
+      - ./app:/app/app


### PR DESCRIPTION
This change makes development faster by:
- enabling live reloading, so any changes to the Rails server are immediately reflected
- mounting the underlying volume, so that the container doesn't have to be rebuilt on every change