### PR TITLE
Remove statutory guidance

### DIFF
--- a/ghre-rails/app/views/pages/statutory_obligations.html.erb
+++ b/ghre-rails/app/views/pages/statutory_obligations.html.erb
@@ -3,12 +3,9 @@
 <%= content_for :before_content do %>
   <a href="/" class="govuk-back-link">Back</a>
 <% end %>
-<h1 class="govuk-heading-xl">
-  Statutory obligations and expectations
-</h1>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <% update_date = t('statutory_obligations.last_update_date').to_date %>
+<div class="govuk-grid-column-two-thirds">
+<% update_date = t('statutory_obligations.last_update_date').to_date %>
     <%= render layout: 'summary', locals: { update_date: update_date, show_updates: @show_updates, page: 'statutory-obligations', has_content: true } do %>
       <ul class="govuk-list govuk-list--bullet">
         <li>
@@ -16,294 +13,22 @@
         </li>
       </ul>
     <% end %>
-    <p class="govuk-body">
-      This page provides information on current remote education obligations and expectations.
-    </p>
-    <h2 id="schools" class="govuk-heading-l">
-      Schools
-    </h2>
-    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-schools">
-      <div class="govuk-accordion__section ">
-        <div class="govuk-accordion__section-header">
-          <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-schools-heading-1">
-              Remote education expectations and duties
-            </span>
-          </h2>
-        </div>
-        <div id="accordion-schools-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-schools-heading-1">
-          <p class="govuk-body">
-            Attendance is mandatory for all pupils of compulsory school age. Schools subject to the
-            <%= link_to_govuk_content("remote education temporary continuity direction", "https://www.gov.uk/government/publications/remote-education-temporary-continuity-direction-explanatory-note") %>
-            are required to provide remote education to pupils covered by the direction where their attendance would be
-            contrary to government guidance or legislation around COVID-19. This includes, for example, where such
-            guidance means that a class, group or a small number of pupils need to self-isolate. All such pupils not
-            physically unwell should have access to remote education as soon as reasonably practicable, which may be the
-            next school day.
-          </p>
-          <p class="govuk-body">
-            Independent Schools (not including academies) are only covered by the remote education temporary continuity
-            direction in relation to state-funded pupils in their schools. However, they are still expected to meet the
-            <%= link_to_govuk_content("Independent School Standards", "https://www.gov.uk/government/publications/regulating-independent-schools") %>
-            in full at all times.
-          </p>
-          <p class="govuk-body">
-            From September 2021, we continue to expect schools to provide remote education for pupils whose attendance
-            would be contrary to government guidance or legislation around Covid-19. Schools should therefore maintain
-            their capabilities to deliver high quality remote education for next academic year.
-          </p>
-          <p class="govuk-body">
-            Where needed, the remote education provided should be equivalent in length to the core teaching pupils would
-            receive in school and should include recorded or live direct teaching time, as well as time for pupils to
-            complete tasks and assignments independently. As a minimum you should provide:
-          </p>
-          <ul class="govuk-list govuk-list--bullet">
-            <li>Key Stage 1: 3 hours a day on average across the cohort, with less for younger children</li>
-            <li>Key Stage 2: 4 hours a day</li>
-            <li>Key Stages 3 and 4: 5 hours a day</li>
-          </ul>
-          <p class="govuk-body">
-            Online video lessons do not necessarily need to be recorded by teaching staff at the school. High quality
-            lessons developed by external providers can be provided in lieu of school led video content.
-          </p>
-          <p class="govuk-body">
-            In developing remote education, we expect you to:
-          </p>
-          <ul class="govuk-list govuk-list--bullet">
-            <li>teach a planned and well-sequenced curriculum so that knowledge and skills are built incrementally</li>
-            <li>have a good level of clarity about what is intended to be taught and practised in each subject so that
-              pupils can progress through the school’s curriculum
-            </li>
-            <li>
-              select a digital platform for remote education provision that will be used consistently across the school
-              in order to allow interaction, assessment and feedback and make sure staff are trained and confident in
-              its use. If schools do not have an education platform in place, they can access free support at
-              <%= link_to_govuk_content("get help with technology", "https://get-help-with-tech.education.gov.uk/") %>
-            </li>
-            <li>
-              overcome barriers to digital access for pupils by, for example:
-              <ul class="govuk-list govuk-list--bullet">
-                <li>distributing school-owned laptops accompanied by a user agreement or contract</li>
-                <li>securing appropriate internet connectivity solutions</li>
-                <li>providing printed resources, such as textbooks and workbooks, to structure learning, supplemented
-                  with other forms of communication to keep pupils on track or answer questions about work
-                </li>
-              </ul>
-            </li>
-            <li>have systems for checking, daily, whether pupils are engaging with their work, and work with families to
-              rapidly identify effective solutions where engagement is a concern
-            </li>
-            <li>identify a named senior leader with overarching responsibility for the quality and delivery of remote
-              education, including that provision meets expectations for remote education
-            </li>
-          </ul>
-          <p class="govuk-body">
-            When teaching pupils remotely we expect schools to:
-          </p>
-          <ul class="govuk-list govuk-list--bullet">
-            <li>set meaningful and ambitious work each day in an appropriate range of subjects</li>
-            <li>
-              consider how to transfer into remote education what we already know about effective teaching in the live
-              classroom by, for example:
-              <ul class="govuk-list govuk-list--bullet">
-                <li>providing frequent, clear explanations of new content, delivered by a teacher or through
-                  high-quality curriculum resources
-                </li>
-                <li>providing opportunities for interactivity, including questioning, eliciting and reflective
-                  discussion
-                </li>
-                <li>providing scaffolded practice and opportunities to apply new knowledge</li>
-                <li>enabling pupils to receive timely and frequent feedback on how to progress, using
-                  digitally-facilitated or whole-class feedback where appropriate
-                </li>
-                <li>using assessment to ensure teaching is responsive to pupils’ needs and addresses any critical gaps
-                  in pupils’ knowledge
-                </li>
-                <li>avoiding an over-reliance on long-term projects or internet research activities</li>
-              </ul>
-            </li>
-          </ul>
-          <p class="govuk-body">
-            We expect you to consider these expectations in relation to the pupils’ age, stage of development or special
-            educational needs, for example where this would place significant demands on parents’ help or support.
-          </p>
-          <p class="govuk-body">
-            We continue to expect schools to publish information about their remote education provision on their
-            websites and this should be kept up to date. An optional template is available to support schools in doing
-            this.
-          </p>
-          <p class="govuk-body">
-            Younger children in Key Stage 1 or Reception often require high levels of parental involvement to support
-            their engagement with remote education, which makes digital provision a particular challenge for this age
-            group. We, therefore, do not expect that solely digital means will be used to teach these pupils remotely.
-          </p>
-          <p class="govuk-body">If pupils with special educational needs or disabilities (SEND) are not able to be in
-            school their teachers are best placed to know how the pupil’s needs can be most effectively met to ensure
-            they continue to make progress.</p>
-          <p class="govuk-body">We recognise that some pupils with SEND may not be able to access remote education
-            without adult support and so expect schools to work with families to deliver an ambitious curriculum
-            appropriate for their level of need.</p>
-          <p class="govuk-body">
-            The requirement for schools within the
-            <%= link_to_govuk_content("2014 Children and Families Act", "https://www.legislation.gov.uk/ukpga/2014/6/contents/enacted") %>
-            to use their best endeavours to secure the special educational provision called for by the pupils’ special
-            educational needs remains in place.</p>
-          <p class="govuk-body">You should work collaboratively with families and put in place reasonable adjustments so
-            that pupils with SEND can successfully access remote education. In this situation, decisions on how
-            provision can be delivered should be informed by relevant considerations including the types of services
-            that the pupil can access remotely.</p>
-          <p class="govuk-body">
-            You can access further information on
-            <%= link_to_govuk_content("supporting pupils and students with SEND", "/send") %>
-            to access remote education.
-          </p>
-        </div>
-      </div>
-      <div class="govuk-accordion__section ">
-        <div class="govuk-accordion__section-header">
-          <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-schools-heading-2">
-              Getting help to deliver remote education
-            </span>
-          </h2>
-        </div>
-        <div id="accordion-schools-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-schools-heading-2">
-          <p class="govuk-body">
-            <%= link_to_govuk_content("Get help with remote education", "/") %>
-            provides information for teachers and leaders, signposting the support package available. We have also
-            published a
-            <%= link_to_govuk_content("review your remote education provision tool", "https://www.gov.uk/government/publications/review-your-remote-education-provision") %>
-            , to support school leaders in reviewing and self-assessing their current remote education offer.
-          </p>
-          <p class="govuk-body">
-            Peer-to-peer advice and training is available through the
-            <%= link_to_govuk_content("EdTech Demonstrator programme", "https://get-help-with-tech.education.gov.uk/EdTech-demonstrator-programme") %>
-            .
-          </p>
-          <p class="govuk-body">
-            You can find information about devices and connectivity provided by DfE and access support to get set up
-            with a digital platform at
-            <%= link_to_govuk_content("Get help with technology", "https://get-help-with-tech.education.gov.uk/") %>.
-          </p>
-        </div>
-      </div>
-      <div class="govuk-accordion__section ">
-        <div class="govuk-accordion__section-header">
-          <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-schools-heading-3">
-              Delivering remote education safely
-            </span>
-          </h2>
-        </div>
-        <div id="accordion-schools-content-3" class="govuk-accordion__section-content" aria-labelledby="accordion-schools-heading-3">
-          <p class="govuk-body">
-            Keeping children safe online is essential. The statutory guidance
-            <%= link_to_govuk_content("keeping children safe in education", "https://www.gov.uk/guidance/safeguarding-and-remote-education-during-coronavirus-covid-19") %>
-            provides the information on what you should be doing to protect your pupils online. The guidance includes a
-            collection of resources which includes support for:
-          </p>
-          <ul class="govuk-list govuk-list--bullet">
-            <li>safe remote education</li>
-            <li>virtual lessons</li>
-            <li>live streaming</li>
-            <li>information to share with parents and carers to support them in keeping their children safe online</li>
-          </ul>
-          <p class="govuk-body">
-            <%= link_to_govuk_content("Safeguarding and remote education during coronavirus (COVID-19)", "https://www.gov.uk/government/publications/keeping-children-safe-in-education--2") %>
-            provides guidance to help schools and teachers support pupils’ remote education during COVID-19.
-          </p>
-          <p class="govuk-body">
-            For schools delivering their remote education through live and recorded lessons, the following support is
-            available through third-party resources:
-          </p>
-          <ul class="govuk-list govuk-list--bullet">
-            <li>information portals to help schools, parents and staff deliver safe remote education:</li>
-            <li>
-              <%= govuk_link_to("Safe Remote Learning knowledge base", "https://swgfl.org.uk/resources/safe-remote-learning/") %>
-              by SGWfL
-            </li>
-            <li>
-              <%= govuk_link_to("Safeguarding during remote learning and lockdowns", "https://coronavirus.lgfl.net/safeguarding") %>
-              by LGfL
-            </li>
-            <li>
-              <%= govuk_link_to("live remote lessons", "https://swgfl.org.uk/magazine/camera-s-on-or-off-and-other-important-questions-answered-by-the-posh-helpline/") %>
-              – SGWfL article answering questions asked of the Professional Online Safety Helpline addressing key
-              concerns from teachers the National Cyber Security Centre, which includes information on which
-              <%= link_to_govuk_content("video conference service", "https://www.ncsc.gov.uk/guidance/video-conferencing-services-security-guidance-organisations") %>
-              is right for you and using video conferencing services securely
-            </li>
-          </ul>
-        </div>
-      </div>
-      <div class="govuk-accordion__section ">
-        <div class="govuk-accordion__section-header">
-          <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-schools-heading-4">
-              Recording in the attendance register
-            </span>
-          </h2>
-        </div>
-        <div id="accordion-schools-content-4" class="govuk-accordion__section-content" aria-labelledby="accordion-schools-heading-4">
-          <p class="govuk-body">
-            Schools must continue to complete the attendance register for pupils who are receiving remote education.
-          </p>
-          <p class="govuk-body">
-            Read the addendum on
-            <%= link_to_govuk_content("recording attendance in relation to coronavirus (COVID-19)", "https://www.gov.uk/government/publications/school-attendance/addendum-recording-attendance-in-relation-to-coronavirus-covid-19-during-the-2020-to-2021-academic-year") %>
-            for further information. Where there is a different reason for absence, read the
-            <%= link_to_govuk_content("school attendance guidance", "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/907535/School_attendance_guidance_for_2020_to_2021_academic_year.pdf") %>
-            .
-          </p>
-          <p class="govuk-body">
-            Schools should keep a record of, and monitor pupils’ and students’ engagement with remote education, but
-            this does not need to be tracked in the attendance register.
-          </p>
-        </div>
-      </div>
-      <div class="govuk-accordion__section ">
-        <div class="govuk-accordion__section-header">
-          <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-schools-heading-5">
-              Expectations for schools
-            </span>
-          </h2>
-        </div>
-        <div id="accordion-schools-content-5" class="govuk-accordion__section-content" aria-labelledby="accordion-schools-heading-5">
-          <p class="govuk-body">
-            Where restrictions are put in place to contain local outbreaks or pupils and students are required to
-            self-isolate, remote provision can be extended to meet pupils’ and students’ needs. Schools should have
-            contingency plans in place to move quickly to blended or, if necessary, remote education should the need
-            arise.
-            The <%= link_to_govuk_content("schools coronavirus (COVID-19) operational guidance", "https://www.gov.uk/government/collections/guidance-for-schools-coronavirus-covid-19") %>
-            sets out what's expected for remote provision.
-          </p>
-        </div>
-      </div>
-    </div>
-    <h2 id="further-education" class="govuk-heading-l">
-      Further education
-    </h2>
-    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-fe">
-      <div class="govuk-accordion__section ">
-        <div class="govuk-accordion__section-header">
-          <h2 class="govuk-accordion__section-heading">
-            <span class="govuk-accordion__section-button" id="accordion-fe-heading-1">
-              Expectations for further education
-            </span>
-          </h2>
-        </div>
-        <div id="accordion-fe-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-fe-heading-1">
-          <p class="govuk-body">
-            Where restrictions are put in place to contain local outbreaks or pupils and students are required to
-            self-isolate, remote provision can be extended to meet pupils’ and students’ needs. FE colleges should have
-            contingency plans in place to move quickly to blended or, if necessary, remote education should the need
-            arise. The
-            <%= link_to_govuk_content("Further education coronavirus (COVID-19) operational guidance", "https://www.gov.uk/government/publications/coronavirus-covid-19-maintaining-further-education-provision/further-education-coronavirus-covid-19-operational-guidance", "#education-and-training-delivery") %>
-            sets out what’s expected for remote provision.
-          </p>
-        </div>
-      </div>
-    </div>
+  <h1 class="govuk-heading-xl">
+    Statutory obligations and expectations
+  </h1>
+  </div>
+  </div>
+
+  <div class="govuk-grid-row">
+<div class="govuk-grid-column-two-thirds">
+  <p class="govuk-body">
+  The Coronavirus Act 2020 and provision of remote education (England) temporary continuity (no. 2) direction expired on 24 March 2022 meaning that schools no longer have a legal duty to provide remote education.
+  </p>
+  <p class="govuk-body">
+  Where possible schools should provide remote education to allow pupils to keep pace with their education when in-person attendance is either not possible or contrary to government guidance. Schools should therefore continue to be prepared to implement high-quality remote education so that any pupil who is well enough to learn from home, but unable to attend school in person, can continue to do so. 
+  </p>
+  <p class="govuk-body">
+  We have published <%= link_to_govuk_content("guidance on remote education for schools", "https://www.gov.uk/government/publications/providing-remote-education-guidance-for-schools") %>. We will continue to work with the sector on this, learning from the many examples of excellent practice developed during the COVID-19 pandemic.  
+  </p>
   </div>
 </div>

--- a/ghre-rails/config/locales/en.yml
+++ b/ghre-rails/config/locales/en.yml
@@ -33,7 +33,7 @@ en:
   videos_webinars:
     last_update_date: "23/12/2021"
   statutory_obligations:
-    last_update_date: "23/12/2021"
+    last_update_date: "30/03/2022"
   safeguarding:
     last_update_date: "15/03/2021"
   good_teaching_practice:


### PR DESCRIPTION
The legislation that required schools to provide remote education has expired, so we should remove any text that suggests it's still the case

Before:
![image](https://user-images.githubusercontent.com/3410350/160793542-19042d73-59ea-496c-91a3-71615b55a65b.png)


After:
![image](https://user-images.githubusercontent.com/3410350/160793415-654cc454-5ad2-4199-bbb3-df268d856776.png)
